### PR TITLE
fix 'noddc' option

### DIFF
--- a/tex/latex/tud-beamerstyle/beamerouterthemetud.sty
+++ b/tex/latex/tud-beamerstyle/beamerouterthemetud.sty
@@ -435,6 +435,9 @@
 \if@ddc
 \setbeamertemplate{zweitlogo/titlepage}[ddc]
 \setbeamertemplate{zweitlogo/headline}[ddc]
+\else
+\setbeamertemplate{zweitlogo/titlepage}[default]
+\setbeamertemplate{zweitlogo/headline}[default]
 \fi
 
 


### PR DESCRIPTION
Mit der Paketoption 'noddc' werden jetzt die Templates 'titlepage' und 'headline' korrekt gesetzt.