### PR TITLE
Fix STIX OTF font name for luatex

### DIFF
--- a/tex/latex/tud-beamerstyle/beamerfontthemetud.sty
+++ b/tex/latex/tud-beamerstyle/beamerfontthemetud.sty
@@ -162,7 +162,6 @@
       \setmathfont[range={sfit}]{Open Sans Condensed Light Italic}
       \setmathfont[range={bfsfup}]{Open Sans Light}
       \setmathfont[range={bfsfit}]{Open Sans Light Italic}
-      \setmathfont[range=\mathfrak]{STIXGeneral}
       %\setmathfont{Open Sans}
       %\renewcommand*\setminus{\mathbin{\mathsf{\backslash}}}
       % \setmonofont{Open Sans}
@@ -186,6 +185,25 @@
         from the TU Dresden homepage.^^J%
         Alternatively, you could install the corresponding font package^^J%
         (opensans) for your TeX distribution or your operating system.^^J%
+      }%
+    }
+	\IfFontExistsTF{STIX}{
+      \setmathfont[range=\mathfrak]{STIX}
+	}{
+      \PackageError{Beamer Font Theme TUD}{^^J%
+        Die Schrift ,,STIX'' konnte nicht gefunden werden.^^J%
+        Could not load STIX font.%
+      }{%
+        Das bedeutet meist, dass Sie die Fonts von der TU Dresden^^J%
+        herunterladen und in Ihrem Fontverzeichnis installieren müssen.^^J%
+        Alternativ können Sie auch das entsprechende Schriftpacket (stix)^^J%
+        Ihrer TeX-Distribution oder Ihres Betriebssystems installieren.^^J%
+        ^^J%
+        Please install STIX for your Operating system.^^J%
+        This usually means that you have to download the STIX Package^^J%
+        from the TU Dresden homepage.^^J%
+        Alternatively, you could install the corresponding font package^^J%
+        (stix) for your TeX distribution or your operating system.^^J%
       }%
     }
   \else


### PR DESCRIPTION
closes #28

The [CTAN stix](https://ctan.org/pkg/stix) package contains the font named 'STIXGeneral' only as a
Type1 font.  As lualatex cannot load these but needs the OTF font
included in that package, trying to load that font failed.
Now the OTF font is loaded by its generic family name instead.

As STIX and Open Sans are different fonts from different packages, the
font definitions using STIX have been moved to their own section.

I have tested this change by making sure `\mathfrak` symbols are still rendered correctly, they are.